### PR TITLE
chore: update package manager references

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,26 +109,26 @@ behaviour is the same, just without the `useAsyncData()` wrapper around the fetc
 
 ```bash
 # Install dependencies
-npm install
+pnpm install
 
 # Generate type stubs
-npm run dev:prepare
+pnpm run dev:prepare
 
 # Develop with the playground
-npm run dev
+pnpm run dev
 
 # Build the playground
-npm run dev:build
+pnpm run dev:build
 
 # Run ESLint
-npm run lint
+pnpm run lint
 
 # Run Vitest
-npm run test
-npm run test:watch
+pnpm run test
+pnpm run test:watch
 
 # Release new version
-npm run release
+pnpm run release
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
-    "release": "npm run lint && npm run test && npm run prepack && changelogen --release && npm publish && git push --follow-tags",
+    "release": "pnpm run lint && pnpm run test && pnpm run prepack && changelogen --release && pnpm publish && git push --follow-tags",
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest watch"


### PR DESCRIPTION
The `README.md` module development steps currently reference `npm`. However, this module/package is built using `pnpm` and running `npm install` results in an error.

Therefore, I've updated the `README.md` to now use `pnpm` for the module development steps and also updated the `package.json` file to use `pnpm` when running the release command.