### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/composables/shared/useDatoQuery.ts
+++ b/src/runtime/composables/shared/useDatoQuery.ts
@@ -61,7 +61,7 @@ export async function useDatoQuery({ query, variables = {}, subscribe = true }: 
     $datoCms.logger.success(`Query complete: ${uniqueKey}`);
   }
 
-  if (process.client) {
+  if (import.meta.client) {
     if (subscribe === true || (subscribe === 'preview' && preview)) {
       return subscribeToContentUpdates({
         environment,

--- a/src/runtime/helpers/data-fetching.ts
+++ b/src/runtime/helpers/data-fetching.ts
@@ -131,11 +131,11 @@ function isPreviewEnabled(_runtimeConfig: RuntimeConfig): boolean {
  * retrieve it from a serverless function, where we can access the private token from env.
  */
 export async function draftEnabledToken(runtimeConfig: RuntimeConfig) {
-  if (process.server) {
+  if (import.meta.server) {
     return runtimeConfig.datocms.privateDraftEnabledToken;
   }
 
-  if (process.client) {
+  if (import.meta.client) {
     const preview = await $fetch<Preview>('/api/preview');
 
     if (isEnabledPreview(preview)) {


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)