### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ _Note: This module is for Nuxt 3. We do not provide a Nuxt 2 version._
 
 ```bash
 npx nuxi@latest module add datocms
-# npx nuxi@latest module add datocms
-# npx nuxi@latest module add datocms
 ```
 
 2. Add `@hexdigital/nuxt-datocms` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ _Note: This module is for Nuxt 3. We do not provide a Nuxt 2 version._
 1. Add `@hexdigital/nuxt-datocms` dependency to your project
 
 ```bash
-pnpm add -D @hexdigital/nuxt-datocms
-# yarn add --dev @hexdigital/nuxt-datocms
-# npm install --save-dev @hexdigital/nuxt-datocms
+npx nuxi@latest module add datocms
+# npx nuxi@latest module add datocms
+# npx nuxi@latest module add datocms
 ```
 
 2. Add `@hexdigital/nuxt-datocms` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
